### PR TITLE
Add Filtering and Aggregation Processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ make html
 * `pandas`: for data management and processing ([website](https://pandas.pydata.org/))
 * `seaborn`: for colormap generation ([website](https://seaborn.pydata.org/))
 * `jinja2`: for visualization generation ([website](https://jinja.palletsprojects.com/))
+* `scipy`: for support of built-in aggregators([website](https://www.scipy.org/))
 
 ### Development Dependencies
 * `requests-mock`: for mocking request object for testing fetchers ([website](https://requests-mock.readthedocs.io/en/latest/))

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Take a look at the notebooks below to demonstrate the functionality of FTPVL.
 1. [Using `HydraFetcher` and Processors](https://colab.research.google.com/drive/1BIQ-iulDFpzcve7lGJPwLePJ5ETBJ6Ut?usp=sharing)
 2. [Styling tables with `SingleTableVisualizer`](https://colab.research.google.com/drive/1u3EnmIYnTBk-LXZhqNHt_h4aMuq-_cWq?usp=sharing)
 3. [Comparing two different Evaluations](https://colab.research.google.com/drive/1I7InmA6210vIIwdQ7TGHE6aF_WwIm1dM?usp=sharing)
+4. [Filtering and Aggregating an Evaluation](https://colab.research.google.com/drive/1DDwlQFS81RGLL-q8DsgICF-HOC5ir6oS?usp=sharing)
 
 ## Documentation
 Extensive documentation, including a *Getting Started* guide, is available on
@@ -45,6 +46,9 @@ make html
 * `sphinx-rtd-theme`: for documentation generation (theme) ([website](https://github.com/readthedocs/sphinx_rtd_theme))
 
 ## Changes
+### 0.1.6
+* Added support for filter and aggregator processors, fixes [#9](https://github.com/SymbiFlow/FPGA-Tool-Performance-Visualization-Library/issues/9)
+
 ### 0.1.5
 * Added support for custom projects and jobsets in HydraFetcher.
 

--- a/docs/topics/api.rst
+++ b/docs/topics/api.rst
@@ -67,6 +67,15 @@ Processors API
 .. autoclass:: ftpvl.processors.RelativeDiff
     :members:
 
+.. autoclass:: ftpvl.processors.FilterByIndex
+    :members:
+
+.. autoclass:: ftpvl.processors.Aggregate
+    :members:
+
+.. autoclass:: ftpvl.processors.GeomeanAggregate
+    :members:
+
 .. _topics-api-styles:
 
 Styles API

--- a/ftpvl/processors.py
+++ b/ftpvl/processors.py
@@ -1,6 +1,6 @@
 """ Processors transform Evaluations to be more useful when visualized. """
 import math
-from typing import Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Union
 
 import numpy as np
 import pandas as pd
@@ -454,10 +454,10 @@ class FilterByIndex(Processor):
     ----------
     index_name : str
         the name of the index to use when filtering
-    index_value : [type]
+    index_value : Any
         the value to compare with
     """
-    def __init__(self, index_name: str, index_value: str):
+    def __init__(self, index_name: str, index_value: Any):
         self.index_name = index_name
         self.index_value = index_value
     

--- a/ftpvl/processors.py
+++ b/ftpvl/processors.py
@@ -466,9 +466,9 @@ class FilterByIndex(Processor):
     ... ],
     ... index=pd.Index(["a", "b"], name="key")))
     >>> a.process([FilterByIndex("key", "a")]).get_df()
-	    x	y
-    key		
-    a	1	5
+        x    y
+    key
+    a   1    5
     """
     def __init__(self, index_name: str, index_value: Any):
         self.index_name = index_name
@@ -498,6 +498,17 @@ class Aggregate(Processor):
     func : Callable[[pd.Series], Union[int, float]]
         a function that takes a Pandas Series and aggregates it into a single
         number, possibly a NaN value
+
+    Examples
+    --------
+    >>> a = Evaluation(pd.DataFrame(
+    ... data=[
+    ...     {"x": 1, "y": 5},
+    ...     {"x": 4, "y": 10}
+    ... ]))
+    >>> a.process([Aggregate(lambda x: x.sum())]).get_df()
+        x    y
+    0   5    15
     """
     def __init__(self, func: Callable[[pd.Series], Union[int, float]]):
         self.func = func
@@ -514,6 +525,17 @@ class GeomeanAggregate(Aggregate):
     numeric metric.
 
     Subclass of Aggregate class.
+
+    Examples
+    --------
+    >>> a = Evaluation(pd.DataFrame(
+    ... data=[
+    ...     {"x": 1, "y": 8},
+    ...     {"x": 4, "y": 8}
+    ... ]))
+    >>> a.process([GeomeanAggregate()).get_df()
+        x    y
+    0   2    8
     """
     def __init__(self):
         def geomean(x):

--- a/ftpvl/processors.py
+++ b/ftpvl/processors.py
@@ -443,7 +443,7 @@ class RelativeDiff(Processor):
 
 class FilterByIndex(Processor):
     """
-    Processor that filters an Evaluation by comparing a specified value
+    Processor that filters an Evaluation by matching a specified index value
     after indexing.
 
     This is best used in a processing pipeline after the Reindex processor.
@@ -487,11 +487,12 @@ class FilterByIndex(Processor):
 
 class Aggregate(Processor):
     """
-    Processor that allows you to aggregate an entire Evaluation using a specified
-    function.
+    Processor that allows you to aggregate all the numeric fields of an
+    Evaluation using a specified function.
 
-    This is useful for custom aggregators and as a superclass for specific
-    aggregator implementations, such as GeomeanAggregate.
+    This acts as a superclass for specific aggregator implementations, such as
+    GeomeanAggregate. It can also be used for custom aggregations, by supplying
+    an aggregator function to the constructor.
 
     Parameters
     ----------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ pandas
 requests-mock
 seaborn
 jinja2
+scipy
 
 pylint
 pytest

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ URL = 'https://github.com/TypingKoala/FPGA-Tool-Performance-Visualization-Librar
 EMAIL = 'me@johnnybui.com'
 AUTHOR = 'Johnny Bui'
 REQUIRES_PYTHON = '>=3.6.0'
-VERSION = '0.1.5'
+VERSION = '0.1.6'
 
 # What packages are required for this module to be executed?
 REQUIRED = [

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -590,6 +590,30 @@ class TestProcessor:
         assert_frame_equal(result2.get_df(), expected_df2)
         assert result2.get_eval_id() == 20
 
+    def test_aggregate_exclude_nonnumeric(self):
+        """ Check if aggregate processor excludes fields that are non-numeric """
+        df = pd.DataFrame(
+            [
+                {"a": 1, "b": 1, "c": "a"},
+                {"a": 1, "b": 2, "c": "b"},
+                {"a": 3, "b": 3, "c": "c"},
+                {"a": 4, "b": 4, "c": "d"},
+                {"a": 5, "b": 5, "c": "e"},
+            ]
+        )
+        eval1 = Evaluation(df, eval_id=20)
+
+        pipeline = [Aggregate(lambda x: x.sum())]
+        result = eval1.process(pipeline)
+
+        expected_df = pd.DataFrame(
+            [
+                {"a": 14, "b": 15}
+            ]
+        )
+        assert_frame_equal(result.get_df(), expected_df)
+        assert eval1.get_eval_id() == 20
+
     def test_geomean_aggregate(self):
         """ Test built-in geomean aggregator """
         df = pd.DataFrame(

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -498,7 +498,7 @@ class TestProcessor:
 
         assert_frame_equal(expected, result)
 
-    def test_filterbyindex(self):
+    def test_filterbyindex_multindex(self):
         """ tests if filtering by index works for multi-index dataframe """
         # test dataframe
         # {"group": "a", "key": "a", "value": 10},
@@ -528,6 +528,29 @@ class TestProcessor:
 
         expected_index = pd.Index(["a"], name="group")
         expected_df = pd.DataFrame({"value": [10]}, index=expected_index)
+
+        assert_frame_equal(result.get_df(), expected_df)
+        assert result.get_eval_id() == 10
+
+    def test_filterbyindex_singleindex(self):
+        """ tests if filtering by index works for single-index dataframe """
+        # test dataframe
+        # {"group": "a", "key": "a", "value": 10},
+        # {"group": "a", "key": "b", "value": 5},
+        # {"group": "a", "key": "c", "value": 3},
+        # {"group": "b", "key": "d", "value": 100},
+        # {"group": "b", "key": "e", "value": 31}
+
+        idx_array = ["a", "a", "a", "b", "b"]
+        index = pd.Index(idx_array, name="key")
+        df = pd.DataFrame({"value": [10, 5, 3, 100, 31]}, index=index)
+        eval1 = Evaluation(df, eval_id=10)
+
+        # filter by first index
+        pipeline = [FilterByIndex("key", "a")]
+        result = eval1.process(pipeline)
+        expected_index = pd.Index(["a", "a", "a"], name="key")
+        expected_df = pd.DataFrame({"value": [10, 5, 3]}, index=expected_index)
 
         assert_frame_equal(result.get_df(), expected_df)
         assert result.get_eval_id() == 10


### PR DESCRIPTION
Fixes #9 by implementing FilterByIndex, Aggregate, and GeomeanAggregate.

These new features allow for users to filter an evaluation by values stored in the index, such as by project and/or toolchain. Once filtered, the new aggregators reduce the filtered test runs into a single line, which will be used in the future for performance comparison over time.

A demo of the new features can be found [here](https://colab.research.google.com/drive/1DDwlQFS81RGLL-q8DsgICF-HOC5ir6oS?usp=sharing)

